### PR TITLE
Fix results screen on safari

### DIFF
--- a/src/components/ResultsScreen.css
+++ b/src/components/ResultsScreen.css
@@ -16,6 +16,7 @@
   display: flex;
   width: 100%;
   height: 100%;
+  min-height: 0;
   padding: 1vh 1vh;
   box-sizing: border-box;
   overflow-y: clip;


### PR DESCRIPTION
Safari still shoves the buttons down when the list of words is long